### PR TITLE
outputの高速化

### DIFF
--- a/examples/large_case.rs
+++ b/examples/large_case.rs
@@ -1,0 +1,21 @@
+extern crate pretable;
+
+use pretable::PreTable;
+
+pub fn main() {
+    let n = 1_000_000;
+
+    let numbers = (0..n).map(|i| (i + 1).to_string()).collect::<Vec<_>>();
+
+    let mut table = PreTable::new();
+    table.set_header(vec!["i"]);
+    for n in numbers.iter() {
+        table.add_body(vec![n]);
+    }
+
+    let output = table.output();
+
+    // 処理が削除されないように output を使うフリをする。
+    let t = output.as_bytes();
+    println!("{}", t[3] + t[t.len() - 3]);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,9 @@ impl PreTable {
 
     fn header(&self) -> String {
         let s: Vec<String> = self.items.iter().map(|item| {
-            format!("{}{}", self.vertical_char, Self::format_center(&item.key, &item.max_value_len + 2))
+            let mut s = self.vertical_char.to_string();
+            Self::format_center(&item.key, &item.max_value_len + 2, &mut s);
+            s
         }).collect();
 
         format!("{}{}", s.concat(), self.vertical_char)
@@ -78,13 +80,16 @@ impl PreTable {
                 n - 1
             };
 
-            let result: Vec<_> = r.iter().map(|value| {
-                format!("{}{}", self.vertical_char, Self::format_center(match value {
+            let mut result = String::new();
+            for ref value in r {
+                result.push(self.vertical_char);
+                Self::format_center(match value {
                     &Some(vv) => vv,
                     &None => "",
-                }, value_len_vec[inc()] + 2))
-            }).collect();
-            vec.push(format!("{}{}", result.concat(), self.vertical_char));
+                }, value_len_vec[inc()] + 2, &mut result);
+            }
+            result.push(self.vertical_char);
+            vec.push(result);
         }
 
         vec
@@ -129,10 +134,13 @@ impl PreTable {
         self.corner_char = c;
     }
 
-    fn format_center(v: &str, count: usize) -> String {
+    fn format_center(v: &str, count: usize, buf: &mut String) {
         let start = (count - v.len()) / 2;
         let end = count - v.len() - start;
-        format!("{}{}{}", Self::repeat(b' ', start), v, Self::repeat(b' ', end))
+
+        buf.extend(std::iter::repeat(' ').take(start));
+        *buf += v;
+        buf.extend(std::iter::repeat(' ').take(end));
     }
 
     fn repeat(s: u8, count: usize) -> String {


### PR DESCRIPTION
中間の String の生成を減らすことで出力のパフォーマンスを改善します。

- 大きいサンプルデータとして examples/large_case.rs を追加しました。
- 私の環境で `--release` オプション込みで計測したところ、おおよそ 600 ms → 300 ms に改善しました。(計測は以下のコマンド)

```sh
cargo build --release --examples && time cargo run --release --example large_case
```
